### PR TITLE
Fix booking status update auth handling

### DIFF
--- a/src/components/bookings/BookingStatusUpdateModal.tsx
+++ b/src/components/bookings/BookingStatusUpdateModal.tsx
@@ -41,7 +41,7 @@ const BookingStatusUpdateModal: React.FC<BookingStatusUpdateModalProps> = ({
   loading = false,
 }) => {
   const { toast } = useToast();
-  const [selectedStatus, setSelectedStatus] = useState<BookingStatus | "">("");
+  const [selectedStatus, setSelectedStatus] = useState<BookingStatus | null>(null);
   const [reason, setReason] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [validationErrors, setValidationErrors] = useState<{
@@ -61,7 +61,7 @@ const BookingStatusUpdateModal: React.FC<BookingStatusUpdateModalProps> = ({
   // Reset form when modal opens/closes
   useEffect(() => {
     if (isOpen) {
-      setSelectedStatus("");
+      setSelectedStatus(null);
       setReason("");
       setValidationErrors({});
       setIsSubmitting(false);
@@ -132,7 +132,7 @@ const BookingStatusUpdateModal: React.FC<BookingStatusUpdateModalProps> = ({
       return;
     }
 
-    if (selectedStatus === booking.status) {
+    if (selectedStatus && selectedStatus === booking.status) {
       setValidationErrors({
         general: `Booking is already ${selectedStatus.toLowerCase()}.`,
       });
@@ -145,7 +145,7 @@ const BookingStatusUpdateModal: React.FC<BookingStatusUpdateModalProps> = ({
       // Call the API to update booking status
       await onStatusUpdate(
         booking.id,
-        selectedStatus as BookingStatus,
+        selectedStatus!,
         selectedStatus === BookingStatus.CANCELLED ? reason.trim() : undefined
       );
 
@@ -385,7 +385,7 @@ const BookingStatusUpdateModal: React.FC<BookingStatusUpdateModalProps> = ({
               New Status
             </Label>
             <Select
-              value={selectedStatus}
+              value={selectedStatus ?? ""}
               onValueChange={(value) =>
                 setSelectedStatus(value as BookingStatus)
               }

--- a/src/services/base/BaseService.ts
+++ b/src/services/base/BaseService.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance, AxiosResponse, AxiosError } from "axios";
 import { httpClient } from "@/lib/axios";
+import { tokenUtils } from "@/lib/utils";
 
 // Generic API Response wrapper
 export interface ApiResponse<T> {
@@ -29,11 +30,17 @@ export abstract class BaseService {
     this.baseUrl = baseUrl;
   }
 
+  private getAuthHeaders(): Record<string, string> {
+    const token = tokenUtils.getAuthToken();
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  }
+
   protected async get<T>(url: string, params?: any): Promise<T> {
     return this.executeWithRetry(async () => {
       const fullUrl = `${this.baseUrl}${url}`;
       const response: AxiosResponse<T> = await this.api.get(fullUrl, {
         params,
+        headers: this.getAuthHeaders(),
       });
       return response.data;
     }, `GET ${this.baseUrl}${url}`);
@@ -43,7 +50,8 @@ export abstract class BaseService {
     return this.executeWithRetry(async () => {
       const response: AxiosResponse<T> = await this.api.post(
         `${this.baseUrl}${url}`,
-        data
+        data,
+        { headers: this.getAuthHeaders() }
       );
       return response.data;
     }, `POST ${this.baseUrl}${url}`);
@@ -53,7 +61,8 @@ export abstract class BaseService {
     return this.executeWithRetry(async () => {
       const response: AxiosResponse<T> = await this.api.put(
         `${this.baseUrl}${url}`,
-        data
+        data,
+        { headers: this.getAuthHeaders() }
       );
       return response.data;
     }, `PUT ${this.baseUrl}${url}`);
@@ -63,7 +72,8 @@ export abstract class BaseService {
     return this.executeWithRetry(async () => {
       const response: AxiosResponse<T> = await this.api.patch(
         `${this.baseUrl}${url}`,
-        data
+        data,
+        { headers: this.getAuthHeaders() }
       );
       return response.data;
     }, `PATCH ${this.baseUrl}${url}`);
@@ -72,7 +82,8 @@ export abstract class BaseService {
   protected async delete<T>(url: string): Promise<T> {
     return this.executeWithRetry(async () => {
       const response: AxiosResponse<T> = await this.api.delete(
-        `${this.baseUrl}${url}`
+        `${this.baseUrl}${url}`,
+        { headers: this.getAuthHeaders() }
       );
       return response.data;
     }, `DELETE ${this.baseUrl}${url}`);
@@ -100,6 +111,7 @@ export abstract class BaseService {
         {
           headers: {
             "Content-Type": "multipart/form-data",
+            ...this.getAuthHeaders(),
           },
         }
       );
@@ -119,6 +131,7 @@ export abstract class BaseService {
         {
           headers: {
             "Content-Type": "multipart/form-data",
+            ...this.getAuthHeaders(),
           },
         }
       );
@@ -145,7 +158,10 @@ export abstract class BaseService {
     last: boolean;
   }> {
     return this.executeWithRetry(async () => {
-      const response = await this.api.get(`${this.baseUrl}${url}`, { params });
+      const response = await this.api.get(`${this.baseUrl}${url}`, {
+        params,
+        headers: this.getAuthHeaders(),
+      });
       return response.data;
     }, `GET_PAGINATED ${this.baseUrl}${url}`);
   }

--- a/src/types/booking.types.ts
+++ b/src/types/booking.types.ts
@@ -84,6 +84,7 @@ export enum BookingStatus {
   CANCELLED = "CANCELLED",
   COMPLETED = "COMPLETED",
   REJECTED = "REJECTED",
+  NO_SHOW = "NO_SHOW",
 }
 
 export enum PaymentStatus {


### PR DESCRIPTION
## Summary
- ensure JWT header is attached for all BaseService requests
- handle unset status values in BookingStatusUpdateModal
- add NO_SHOW entry to BookingStatus enum

## Testing
- `npm test` *(fails: No test suite found and various assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_689133b37ebc8331952b125bad6366e1